### PR TITLE
Fix a bug when creating CLSplitCascadeViewController without IB

### DIFF
--- a/src/Cascade/CLSplitViewController/CLSplitCascadeViewController.m
+++ b/src/Cascade/CLSplitViewController/CLSplitCascadeViewController.m
@@ -59,9 +59,10 @@
     
     CLSplitCascadeView* view_ = [[CLSplitCascadeView alloc] init];
     self.view = view_;
-
+    
     [view_ setCategoriesView: self.categoriesViewController.view];
     [view_ setCascadeView: self.cascadeNavigationController.view];
+    [view_ setSplitCascadeViewController:self];
 }
 
 


### PR DESCRIPTION
Hard to find this one … I searched for IB configurations like UserInteractionEnabled before seeing that there were a little property set in IB in the sample project ... :)
